### PR TITLE
Fix #2: Properly load faded favicon on suspended tab

### DIFF
--- a/common.js
+++ b/common.js
@@ -131,7 +131,8 @@ function suspend (tab, forced) {
 
         let url = './data/suspend/index.html?title=' +
           encodeURIComponent(tab.title) +
-          '&url=' + encodeURIComponent(tab.url);
+          '&url=' + encodeURIComponent(tab.url) +
+          '&favicon=' + encodeURIComponent(tab.favIconUrl);
 
         chrome.tabs.update(tab.id, {
           url

--- a/data/suspend/index.js
+++ b/data/suspend/index.js
@@ -18,6 +18,10 @@ document.getElementById('date').textContent = (new Date()).toLocaleString();
 document.title = document.querySelector('h1').textContent = search.title || 'Title';
 document.querySelector('h2').textContent = search.url || '...';
 
+function setFavicon(favicon) {
+  document.querySelector('link[rel*="icon"]').href = favicon;
+}
+
 // fav icon
 (function (img) {
   // Source: https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
@@ -40,12 +44,16 @@ document.querySelector('h2').textContent = search.url || '...';
 
     setFavicon(canvas.toDataURL('image/ico'));
   };
-  img.src = search.favicon || chrome.extension.getURL('img/default.ico');
-})(new Image());
 
-function setFavicon(favicon) {
-  document.querySelector('link[rel*="icon"]').href = favicon;
-}
+  if (navigator.userAgent.indexOf("Firefox") !== -1) {
+    img.src = decodeURIComponent(search.favicon) ||
+              chrome.extension.getURL('data/suspend/favicon.png');
+  } else {
+    img.src = 'chrome://favicon/' + decodeURIComponent(search.url) ||
+              chrome.extension.getURL('data/suspend/favicon.png');
+  }
+
+})(new Image());
 
 document.addEventListener('dblclick', () => {
   chrome.runtime.sendMessage({

--- a/data/suspend/index.js
+++ b/data/suspend/index.js
@@ -20,6 +20,9 @@ document.querySelector('h2').textContent = search.url || '...';
 
 // fav icon
 (function (img) {
+  // Source: https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
+  img.crossOrigin = "anonymous";  // This enables CORS
+
   img.onload = () => {
     let canvas = document.querySelector('canvas');
     let ctx = canvas.getContext('2d');
@@ -35,10 +38,14 @@ document.querySelector('h2').textContent = search.url || '...';
     ctx.arc(img.width * 0.75, img.height * 0.75, img.width * 0.25, 0, 2 * Math.PI, false);
     ctx.fill();
 
-    document.querySelector('link[rel*="icon"]').href = canvas.toDataURL('image/ico');
+    setFavicon(canvas.toDataURL('image/ico'));
   };
-  img.src = 'chrome://favicon/' + search.url;
+  img.src = search.favicon || chrome.extension.getURL('img/default.ico');
 })(new Image());
+
+function setFavicon(favicon) {
+  document.querySelector('link[rel*="icon"]').href = favicon;
+}
 
 document.addEventListener('dblclick', () => {
   chrome.runtime.sendMessage({


### PR DESCRIPTION
This pull request fixes issue #2 where the favicon only loads as the default coffee icon. Now the original favicon is loaded (with fade effect). 

Some technical details:
To do this, I needed a way to pass the favicon image source so that I can use it in `data/suspend/index.js`. I figured out that I could pass the favicon URL from `common.js`. Not sure if this is the best way to do it, but it seemed the most straightforward. I also took some inspiration from [The Great Suspender](https://github.com/deanoemcke/thegreatsuspender/blob/master/src/js/suspended.js#L29) Chrome extension. 

Let me know if there's anything else you'd like to see. I am happy to discuss this.