### PR TITLE
Implement #14: keyboard shortcuts for suspend and unsuspend tab

### DIFF
--- a/common.js
+++ b/common.js
@@ -333,6 +333,13 @@ if (chrome.app && chrome.app.getDetails) {
   });
 }
 
+// Keyboard shortcuts
+chrome.commands.onCommand.addListener(function(command) {
+  if (command === 'suspend-tab' || command == 'unsuspend-tab') {
+    app.emit(command);
+  }
+});
+
 // FAQs
 chrome.storage.local.get('version', prefs => {
   let version = chrome.runtime.getManifest().version;

--- a/manifest.json
+++ b/manifest.json
@@ -47,5 +47,15 @@
       "matches": ["*://*/*"],
       "js": ["data/idle.js"]
     }
-  ]
+  ],
+  "commands": {
+    "suspend-tab": {
+      "description": "Suspend active tab",
+      "suggested_key": { "default": "Ctrl+Shift+E" }
+    },
+    "unsuspend-tab": {
+      "description": "Unsuspend active tab",
+      "suggested_key": { "default": "Ctrl+Shift+U"}
+    }
+  }
 }


### PR DESCRIPTION
I decided to implement issue #14.

The keyboard shortcuts I implemented are:
- Suspend current tab: **Ctrl+Shift+E** 
- Unsuspend current tab: **Ctrl+Shift+U**

Firefox has a lot of keyboard shortcuts reserved by default, so I wasn't left with much choice. If you find something that is more preferable, let me know and I'll be glad to change it. 