### PR TITLE
Eliminate discrepancy between code and doc

### DIFF
--- a/data/options/index.html
+++ b/data/options/index.html
@@ -37,7 +37,7 @@
   <table>
     <tr>
       <td>after (in minutes)<sup>1</sup>:</td>
-      <td><input id="timeout" type="number" min="5"></td>
+      <td><input id="timeout" type="number" min="1"></td>
     </tr>
     <tr>
       <td>and if number of tabs exceeds<sup>2</sup>:</td>


### PR DESCRIPTION
The minimum value for Timeout now follows the footnote; fixes #37.