### PR TITLE
Fix typo in context menu

### DIFF
--- a/common.js
+++ b/common.js
@@ -77,7 +77,7 @@ app.on('prefs-ready', () => {
   }
 });
 chrome.contextMenus.create({
-  title: 'Unuspend this tab',
+  title: 'Unsuspend this tab',
   contexts,
   onclick: (info, tab) => app.emit('unsuspend-tab', [tab])
 });

--- a/manifest.json
+++ b/manifest.json
@@ -56,7 +56,7 @@
       "description": "Suspend this tab"
     },
     "unsuspend-tab": {
-      "description": "Unuspend this tab"
+      "description": "Unsuspend this tab"
     },
     "suspend-all": {
       "description": "Suspend all tabs"


### PR DESCRIPTION
Replace "Unuspend" with "Unsuspend".